### PR TITLE
Add DaemonFlush and fix memory leak

### DIFF
--- a/rrd_c.go
+++ b/rrd_c.go
@@ -471,6 +471,7 @@ func DaemonFetch(filename, cf string, start, end time.Time, step time.Duration, 
 	var cDaemon *C.char
 	if daemon != nil {
 		cDaemon = C.CString(*daemon)
+		defer freeCString(cDaemon)
 	}
 
 	var (
@@ -510,6 +511,17 @@ func DaemonFetch(filename, cf string, start, end time.Time, step time.Duration, 
 	sliceHeader.Len = valuesLen
 	sliceHeader.Data = uintptr(unsafe.Pointer(cData))
 	return FetchResult{filename, cf, start, end, step, dsNames, rowCnt, values}, nil
+}
+
+// DaemonFlush instructs the daemon to flush the given RRD file.
+func DaemonFlush(daemon, filename string) error {
+	cDaemon := C.CString(daemon)
+	defer freeCString(cDaemon)
+	fn := C.CString(filename)
+	defer freeCString(fn)
+
+	var ret C.int
+	return makeError(C.rrdDaemonFlush(&ret, cDaemon, fn))
 }
 
 // FreeValues free values memory allocated by C.

--- a/rrdfunc.c
+++ b/rrdfunc.c
@@ -69,9 +69,9 @@ char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *
 	return rrdError();
 }
 
-char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename)
+char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename) {
 	rrd_clear_error();
-	*ret = rrdc_flush_if_daemon(daemon, filename)
+	*ret = rrdc_flush_if_daemon(daemon, filename);
 	return rrdError();
 }
 

--- a/rrdfunc.c
+++ b/rrdfunc.c
@@ -69,6 +69,12 @@ char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *
 	return rrdError();
 }
 
+char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename)
+	rrd_clear_error();
+	*ret = rrdc_flush_if_daemon(daemon, filename)
+	return rrdError();
+}
+
 char *rrdXport(int *ret, int argc, char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data) {
 	rrd_clear_error();
 	*ret = rrd_xport(argc, argv, xsize, start, end, step, col_cnt, legend_v, data);

--- a/rrdfunc.h
+++ b/rrdfunc.h
@@ -5,6 +5,6 @@ extern char *rrdGraph(rrd_info_t **ret, int argc, char **argv);
 extern char *rrdInfo(rrd_info_t **ret, char *filename);
 extern char *rrdDaemonFetch(int *ret, char *daemon, char *filename, const char *cf, time_t *start, time_t *end, unsigned long *step, unsigned long *ds_cnt, char ***ds_namv, double **data);
 extern char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *end, unsigned long *step, unsigned long *ds_cnt, char ***ds_namv, double **data);
-extern char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename)
+extern char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename);
 extern char *rrdXport(int *ret, int argc, char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data);
 extern char *arrayGetCString(char **values, int i);

--- a/rrdfunc.h
+++ b/rrdfunc.h
@@ -5,5 +5,6 @@ extern char *rrdGraph(rrd_info_t **ret, int argc, char **argv);
 extern char *rrdInfo(rrd_info_t **ret, char *filename);
 extern char *rrdDaemonFetch(int *ret, char *daemon, char *filename, const char *cf, time_t *start, time_t *end, unsigned long *step, unsigned long *ds_cnt, char ***ds_namv, double **data);
 extern char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *end, unsigned long *step, unsigned long *ds_cnt, char ***ds_namv, double **data);
+extern char *rrdDaemonFlush(int *ret, const char *daemon, const char *filename)
 extern char *rrdXport(int *ret, int argc, char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data);
 extern char *arrayGetCString(char **values, int i);


### PR DESCRIPTION
This adds DaemonFlush, which issues a flush command to the given daemon, for the given RRD file. Also, fix a memory leak in DaemonFetch where the daemon C string wasn't being freed.